### PR TITLE
Update a-f properties whenever necessary; allow string passed in constructor

### DIFF
--- a/CSSMatrix.js
+++ b/CSSMatrix.js
@@ -24,6 +24,10 @@ var CSSMatrix = function(){
 		this.affine = true;
 		m.m11 = m.a = a[0]; m.m12 = m.b = a[1]; m.m14 = m.e = a[4];
 		m.m21 = m.c = a[2]; m.m22 = m.d = a[3]; m.m24 = m.f = a[5];
+	} else if (a.length === 1 && typeof a[0] == 'string') {
+		m.setMatrixValue(a[0]);
+	} else if (a.length > 0) {
+		throw new TypeError('Invalid Matrix Value');
 	}
 };
 

--- a/test/CSSMatrix.js
+++ b/test/CSSMatrix.js
@@ -73,6 +73,11 @@ test("identity", function(Matrix){
 	assertMatrix('matrix3d(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1)', m);
 });
 
+test("str passed in constructor", function(Matrix){
+	var m = new Matrix('matrix(1, 0, 0, 1, 100, 200)');
+	assertMatrix('matrix(1, 0, 0, 1, 100, 200)', m);
+});
+
 test("setMatrixValue 2d", function(Matrix){
 	var m = new Matrix();
 	m.setMatrixValue('matrix(1, 0, 0, 1, 100, 200)');


### PR DESCRIPTION
I've noticed that WebKitCSSMatrix updates the a-f properties as well as the mxx properties, so I added that (including test). Same goes for passing a matrix string to the constructor (e.g. `new CSSMatrix('matrix(1,2,3,4,5,6)')`).
